### PR TITLE
Allow Single ARV selection and make other 2 ARVs optional

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/ArvRegimenFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/ArvRegimenFragmentController.java
@@ -141,17 +141,20 @@ public class ArvRegimenFragmentController {
 			require(errors, "patient");
 			require(errors, "startDate");
 			require(errors, "arv1");
-			require(errors, "arv2");
-			require(errors, "arv3");
+			/**
+			 * First ARV is mandatory, while the other two are optional.
+			 */
+			/*require(errors, "arv2");
+			require(errors, "arv3");*/
 			require(errors, "dosage1");
-			require(errors, "dosage2");
-			require(errors, "dosage3");
+			/*require(errors, "dosage2");
+			require(errors, "dosage3");*/
 			require(errors, "units1");
-			require(errors, "units2");
-			require(errors, "units3");
+			/*require(errors, "units2");
+			require(errors, "units3");*/
 			require(errors, "frequency1");
-			require(errors, "frequency2");
-			require(errors, "frequency3");
+			/*require(errors, "frequency2");
+			require(errors, "frequency3");*/
 		}
 		
 		/**
@@ -166,11 +169,17 @@ public class ArvRegimenFragmentController {
 			}
 			
 			DrugOrder o1 = newDrugOrder(patient, startDate, arv1, dosage1, units1, frequency1);
-			DrugOrder o2 = newDrugOrder(patient, startDate, arv2, dosage2, units2, frequency2);
-			DrugOrder o3 = newDrugOrder(patient, startDate, arv3, dosage3, units3, frequency3);
 			Context.getOrderService().saveOrder(o1);
-			Context.getOrderService().saveOrder(o2);
-			Context.getOrderService().saveOrder(o3);
+			
+			if (arv2 != null) {
+				DrugOrder o2 = newDrugOrder(patient, startDate, arv2, dosage2, units2, frequency2);
+				Context.getOrderService().saveOrder(o2);
+			}
+			if (arv3 != null) {
+				DrugOrder o3 = newDrugOrder(patient, startDate, arv3, dosage3, units3, frequency3);
+				Context.getOrderService().saveOrder(o3);
+			}
+					
 		}
 		
 		/**


### PR DESCRIPTION
This fix is to allow Clinicians to select only one ARV while administering it to a patient. The first ARV is mandatory while the other two are optional.

Test Cases:
1. Create new patient. Assign 1 ARV. Saved successfully.
2. Stop ARV on patient from Test Case 1. Add 2 ARVs. Saved successfully.
3. Stop ARV on patient from Test Case 1. Add 3 ARVs. Saved successfully.
4. Stop ARV on patient from Test Case 1. Add ARV but the second one and save. Saving failed.
5. Stop ARV on patient from Test Case 1. Add ARV but the third one and save. Saving failed.
6. Stop ARV on patient from Test Case 1. Add ARV but the first and third one. Saved successfully.
7. Stop ARV on patient from Test Case 1. Add ARV but the first and second one. Saved successfully.
