### PR TITLE
Rest Reporting web service fix for delimiter in URL

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/report/KenyaEmrDataSetDefinitionPersister.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/report/KenyaEmrDataSetDefinitionPersister.java
@@ -117,7 +117,7 @@ public class KenyaEmrDataSetDefinitionPersister implements DataSetDefinitionPers
 
         @Override
         public String toString() {
-            return managerClassname + ":" + dsdName;
+            return managerClassname.replaceAll("\\.", "-") + ":" + dsdName;
         }
     }
 


### PR DESCRIPTION
Previous URL - http://localhost:8080/openmrs/ws/rest/reporting/dataset/org.openmrs.module.kenyaemr.report.Moh731Report:MOH%20731%20Indicator%20Report%20DSD?startDate=2012-01-01&endDate=2012-10-31

New URL -
http://localhost:8080/openmrs/ws/rest/reporting/dataset/org-openmrs-module-kenyaemr-report-Moh731Report:MOH%20731%20Indicator%20Report%20DSD?startDate=2012-01-01&endDate=2012-10-31

Replacing "." with "-" allows the URL parameters to get through without truncation.
