### PR TITLE
Fix for type forward concept search

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/BugWorkaroundFormController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/BugWorkaroundFormController.java
@@ -34,7 +34,7 @@ public class BugWorkaroundFormController {
 	 * The HTML Form Entry widget does this search relative to the current directory, but this doesn't work
 	 * for us since we have a custom HTML Form Entry page.
 	 */
-	@RequestMapping("/pages/conceptSearch.form")
+	@RequestMapping("/kenyaemr/conceptSearch.form")
 	public void htmlFormEntryConceptSearch(
 			ModelMap model,
 			HttpServletRequest request,


### PR DESCRIPTION
Replaced RequestMapping annotation from  "/pages/conceptSearch.form" to "/kenyaemr/conceptSearch.form"

Test Cases:
1. Other Medications form -> type forward should work on the Drug textbox
2. HIV Addendum form -> type forward should work on the Diagnosis textbox
