### PR TITLE
Optional phone number

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/RegistrationEditPatientFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/RegistrationEditPatientFragmentController.java
@@ -303,7 +303,14 @@ public class RegistrationEditPatientFragmentController {
 			if (StringUtils.isBlank(hivIdNumber.getIdentifier())) {
 				hivIdNumber = null;
 			}
-
+			if (!(StringUtils.isBlank(telephoneContact.getValue()))) {
+				if (!telephoneContact.getValue().trim().matches("\\d{10}")) {
+					errors.rejectValue("telephoneContact", "If Phone Number is provided then it  must be 10 digits long");
+				}
+			}
+			else {
+				telephoneContact = null;
+			}
 			require(errors, "gender");
 			require(errors, "birthdate");
 
@@ -311,10 +318,6 @@ public class RegistrationEditPatientFragmentController {
 			validateField(errors, "personAddress");
 			validateField(errors, "patientClinicNumber");
 			validateField(errors, "hivIdNumber");
-
-			if (!telephoneContact.getValue().trim().matches("\\d{10}")) {
-				errors.rejectValue("telephoneContact", "Phone Number must be 10 digits long");
-			}
 		}
 
 		public Patient save() {


### PR DESCRIPTION
The phone number is no longer required during registration of patients but optional. If the field is left empty it accepts, but when a number is provided, a normal phone validation rules are followed.
