### PR TITLE
Fixed the MCHMS Partner HIV Test Date Concept Mismatch Issue

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/mchms/TestedForHivInMchmsCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/mchms/TestedForHivInMchmsCalculation.java
@@ -72,24 +72,24 @@ public class TestedForHivInMchmsCalculation extends BaseEmrCalculation {
 		CalculationResultMap resultMap = new CalculationResultMap();
 
 		for (Integer ptId : cohort) {
-			Concept patientsLastHivStatus = EmrCalculationUtils.codedObsResultForPatient(lastHivStatusObss, ptId);
-			Date patientsLastHivTestDate = EmrCalculationUtils.datetimeObsResultForPatient(lastHivTestDateObss, ptId);
+			Concept lastHivStatus = EmrCalculationUtils.codedObsResultForPatient(lastHivStatusObss, ptId);
+			Date lastHivTestDate = EmrCalculationUtils.datetimeObsResultForPatient(lastHivTestDateObss, ptId);
 
 			CalculationResult activePatientProgram = activePatientPrograms.get(ptId);
 
 			boolean qualified = false;
 			if (aliveMchmsPatients.contains(ptId)
-					&& (patientsLastHivStatus != null &&
-					(patientsLastHivStatus.equals(Dictionary.getConcept(Dictionary.POSITIVE))
-							|| patientsLastHivStatus.equals(Dictionary.getConcept(Dictionary.NEGATIVE))))
+					&& (lastHivStatus != null &&
+					(lastHivStatus.equals(Dictionary.getConcept(Dictionary.POSITIVE))
+							|| lastHivStatus.equals(Dictionary.getConcept(Dictionary.NEGATIVE))))
 					&& (activePatientProgram != null)) {
 				Date enrollmentDate = ((PatientProgram) activePatientProgram.getValue()).getDateEnrolled();
 				Date deliveryDate = EmrCalculationUtils.datetimeObsResultForPatient(lastDeliveryDateObss, ptId);
 				if (deliveryDate != null && deliveryDate.before(enrollmentDate)) {
 					deliveryDate = null;
 				}
-				qualified = qualifiedByStage(stage, enrollmentDate, patientsLastHivTestDate, deliveryDate)
-						&& (result == null ? true : result.equals(patientsLastHivStatus));
+				qualified = qualifiedByStage(stage, enrollmentDate, lastHivTestDate, deliveryDate)
+						&& (result == null ? true : result.equals(lastHivStatus));
 			}
 			resultMap.put(ptId, new BooleanResult(qualified, this, context));
 		}

--- a/omod/src/main/webapp/resources/htmlforms/mchms/mchmsEnrollment.html
+++ b/omod/src/main/webapp/resources/htmlforms/mchms/mchmsEnrollment.html
@@ -192,7 +192,7 @@
 </tr>
 <tr>
 	<td valign="top">
-		<legend>Maternal Profile</legend>
+		<legend>Maternal/Antenatal Profile</legend>
 		<table align="center" width="100%" class="tb1">
 			<tr>
 				<td width="250">ANC No:</td>
@@ -238,17 +238,17 @@
 						 id="ultrasound-edd"/>
 				</td>
 			</tr>
-		</table>
-	</td>
-	<td valign="top">
-		<legend>Antenatal Profile</legend>
-		<table align="center" width="100%" class="tb1">
 			<tr>
 				<td width="250">Blood Group/Rhesus:</td>
 				<td>
 					<obs conceptId="300AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
 				</td>
 			</tr>
+		</table>
+	</td>
+	<td valign="top">
+		<legend>Maternal/Antenatal Profile</legend>
+		<table align="center" width="100%" class="tb1">
 			<tr>
 				<td>Serology:</td>
 				<td>
@@ -294,7 +294,7 @@
 			<tr>
 				<td width="250">Partner HIV Test Date:</td>
 				<td>
-					<obs conceptId="162079AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+					<obs conceptId="160082AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Fixed the MCHMS Partner HIV Test Date Concept Mismatch issue that was causing the NPE leading to MOH 731 not getting generated successfully. PT: https://www.pivotaltracker.com/s/projects/646783/stories/62774738
