### PR TITLE
Tb bug fix hiv+ not tbtx not on ipt

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/ipt/NotOnIptNotInTbProgramCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/ipt/NotOnIptNotInTbProgramCalculation.java
@@ -17,6 +17,7 @@ import org.openmrs.module.kenyacore.calculation.Calculations;
 import org.openmrs.module.kenyacore.calculation.Filters;
 import org.openmrs.module.kenyacore.calculation.PatientFlagCalculation;
 import org.openmrs.module.kenyaemr.calculation.EmrCalculationUtils;
+import org.openmrs.module.kenyaemr.metadata.HivMetadata;
 import org.openmrs.module.kenyaemr.metadata.IPTMetadata;
 import org.openmrs.module.kenyaemr.metadata.TbMetadata;
 import org.openmrs.module.metadatadeploy.MetadataUtils;
@@ -34,13 +35,15 @@ public class NotOnIptNotInTbProgramCalculation extends AbstractPatientCalculatio
 
 		Program iptProgram = MetadataUtils.existing(Program.class, IPTMetadata._Program.IPT);
 		Program tbProgram = MetadataUtils.existing(Program.class, TbMetadata._Program.TB);
+		Program hivProgram = MetadataUtils.existing(Program.class, HivMetadata._Program.HIV);
 
 		EncounterType iptOutcome = MetadataUtils.existing(EncounterType.class, IPTMetadata._EncounterType.IPT_OUTCOME);
 
 		// Get all patients who are alive and initiated into IPT
 		Set<Integer> alive = Filters.alive(cohort, context);
-		Set<Integer> onIptProgram = Filters.inProgram(iptProgram, alive, context);
+		Set<Integer> onIpt = Filters.inProgram(iptProgram, alive, context);
 		Set<Integer> inTbProgram = Filters.inProgram(tbProgram, alive, context);
+		Set<Integer> inHivProgram = Filters.inProgram(tbProgram, alive, context);
 
 		CalculationResultMap lastIptMap = Calculations.lastEncounter(iptOutcome, alive, context);
 		CalculationResultMap ret = new CalculationResultMap();
@@ -49,7 +52,7 @@ public class NotOnIptNotInTbProgramCalculation extends AbstractPatientCalculatio
 
 			Boolean notOnIpt = false;
 
-			if (alive.contains(ptId) && !inTbProgram.contains(ptId) && !onIptProgram.contains(ptId)) {
+			if (alive.contains(ptId) && inHivProgram.contains(ptId) && !inTbProgram.contains(ptId) && !onIpt.contains(ptId)) {
 				
 				Encounter lastIptEncounter = EmrCalculationUtils.encounterResultForPatient(lastIptMap, ptId);
 

--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/ipt/NotOnIptNotInTbProgramCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/ipt/NotOnIptNotInTbProgramCalculation.java
@@ -43,7 +43,7 @@ public class NotOnIptNotInTbProgramCalculation extends AbstractPatientCalculatio
 		Set<Integer> alive = Filters.alive(cohort, context);
 		Set<Integer> onIpt = Filters.inProgram(iptProgram, alive, context);
 		Set<Integer> inTbProgram = Filters.inProgram(tbProgram, alive, context);
-		Set<Integer> inHivProgram = Filters.inProgram(tbProgram, alive, context);
+		Set<Integer> inHivProgram = Filters.inProgram(hivProgram, alive, context);
 
 		CalculationResultMap lastIptMap = Calculations.lastEncounter(iptOutcome, alive, context);
 		CalculationResultMap ret = new CalculationResultMap();


### PR DESCRIPTION
Routine bug fix. Updated the calculation class 'NotOnIptNotInTbProgramCalculation'. Added a filter to pick patients in HIV program only. This had previously been oerlooked